### PR TITLE
Admin can't delete it self

### DIFF
--- a/src/components/TableEditDelete.vue
+++ b/src/components/TableEditDelete.vue
@@ -17,6 +17,7 @@ section#table-edit-delete
 			icon-left='trash-alt'
 			class='has-text-white'
 			@click='launchDeleteConfirmation()'
+			v-if="userType !== 'admin'"
 		)
 </template>
 

--- a/tests/unit/table-edit-delete.spec.js
+++ b/tests/unit/table-edit-delete.spec.js
@@ -1,107 +1,121 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils'
-import Buefy from 'buefy'
-import TableEditDelete from '@/components/TableEditDelete.vue'
-import ServiceForm from '@/components/ServiceForm.vue'
-import CreateUserForm from '@/components/CreateUserForm.vue'
-import BreedForm from '@/components/BreedForm.vue'
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Buefy from 'buefy';
+import TableEditDelete from '@/components/TableEditDelete.vue';
+import ServiceForm from '@/components/ServiceForm.vue';
+import CreateUserForm from '@/components/CreateUserForm.vue';
+import BreedForm from '@/components/BreedForm.vue';
 
-const localVue = createLocalVue()
-localVue.use(Buefy)
+const localVue = createLocalVue();
+localVue.use(Buefy);
 
 const wrapper = shallowMount(TableEditDelete, {
 	propsData: {
 		id: '123',
 		text: 'message',
-		type: 'type'
-	}, localVue })
+		type: 'type',
+		userType: ''
+	}, localVue });
 
 describe('TableEditDelete Component', () => {
-	const props = wrapper.props()
+	const props = wrapper.props();
 	it('Should has two props data', () => {
-		expect(typeof props.id).toBe('string')
-		expect(typeof props.text).toBe('string')
-		expect(typeof props.type).toBe('string')
-	})
+		expect(typeof props.id).toBe('string');
+		expect(typeof props.text).toBe('string');
+		expect(typeof props.type).toBe('string');
+		expect(typeof props.userType).toBe('string');
+	});
 
-	const data = TableEditDelete.data()
+	const data = TableEditDelete.data();
 	it('Should sets the correct default data', () => {
-		expect(typeof TableEditDelete.data).toBe('function')
-		expect(data.isForServices).toBeFalsy()
-		expect(data.isForUsers).toBeFalsy()
-		expect(data.isForBreed).toBeFalsy()
-	})
+		expect(typeof TableEditDelete.data).toBe('function');
+		expect(data.isForServices).toBeFalsy();
+		expect(data.isForUsers).toBeFalsy();
+		expect(data.isForBreed).toBeFalsy();
+	});
 
-	const main = wrapper.get('#table-edit-delete')
+	const main = wrapper.get('#table-edit-delete');
 	it('Should has a main container', () => {
-		expect(main.exists()).toBeTruthy()
-	})
+		expect(main.exists()).toBeTruthy();
+	});
 
 	it('Should has the Text inside', () => {
-		expect(main.text()).toMatch(props.text)
-	})
+		expect(main.text()).toMatch(props.text);
+	});
 
-	const buttonContainer = main.get('#button-container')
-	const editButton = buttonContainer.get('#edit')
+	const buttonContainer = main.get('#button-container');
+	const editButton = buttonContainer.get('#edit');
 	it('Should has an Edit Button', () => {
-		expect(editButton.exists()).toBeTruthy()
-		expect(editButton.attributes().title).toMatch('Edit')
-		expect(editButton.attributes().type).toMatch('is-warning')
-		expect(editButton.attributes().iconpack).toMatch('fas')
-		expect(editButton.attributes().iconleft).toMatch('edit')
-		expect(editButton.classes()).toContain('has-text-dark')
-	})
+		expect(editButton.exists()).toBeTruthy();
+		expect(editButton.attributes().title).toMatch('Edit');
+		expect(editButton.attributes().type).toMatch('is-warning');
+		expect(editButton.attributes().iconpack).toMatch('fas');
+		expect(editButton.attributes().iconleft).toMatch('edit');
+		expect(editButton.classes()).toContain('has-text-dark');
+	});
 
-	const deleteButton = buttonContainer.get('#delete')
+	const deleteButton = buttonContainer.get('#delete');
 	it('Should has a Delete Button', () => {
-		expect(deleteButton.exists()).toBeTruthy()
-		expect(deleteButton.attributes().title).toMatch('Delete')
-		expect(deleteButton.attributes().type).toMatch('is-danger')
-		expect(deleteButton.attributes().iconpack).toMatch('fas')
-		expect(deleteButton.attributes().iconleft).toMatch('trash-alt')
-		expect(deleteButton.classes()).toContain('has-text-white')
-	})
+		expect(deleteButton.exists()).toBeTruthy();
+		expect(deleteButton.attributes().title).toMatch('Delete');
+		expect(deleteButton.attributes().type).toMatch('is-danger');
+		expect(deleteButton.attributes().iconpack).toMatch('fas');
+		expect(deleteButton.attributes().iconleft).toMatch('trash-alt');
+		expect(deleteButton.classes()).toContain('has-text-white');
+	});
 
 	it('Should has an Init Method', () => {
-		expect(wrapper.vm.init).toBeTruthy()
-	})
+		expect(wrapper.vm.init).toBeTruthy();
+	});
 
 	it('Should has an Edit Method', async () => {
-		expect(wrapper.vm.edit).toBeTruthy()
-		await editButton.vm.$emit('click')
-		expect(editButton.emitted('click')).toHaveLength(1)
-	})
+		expect(wrapper.vm.edit).toBeTruthy();
+		await editButton.vm.$emit('click');
+		expect(editButton.emitted('click')).toHaveLength(1);
+	});
 
 	it('Should has a Delete Method', async () => {
-		expect(wrapper.vm.launchDeleteConfirmation).toBeTruthy()
-		await deleteButton.vm.$emit('click')
-		expect(deleteButton.emitted('click')).toHaveLength(1)
-	})
+		expect(wrapper.vm.launchDeleteConfirmation).toBeTruthy();
+		await deleteButton.vm.$emit('click');
+		expect(deleteButton.emitted('click')).toHaveLength(1);
+	});
 
 	it('Should has imported a ServiceForm Component', () => {
-		expect(wrapper.findComponent(ServiceForm)).toBeTruthy()
-	})
+		expect(wrapper.findComponent(ServiceForm)).toBeTruthy();
+	});
 
 	it('Should has imported a CreateUserForm Component', () => {
-		expect(wrapper.findComponent(CreateUserForm)).toBeTruthy()
-	})
+		expect(wrapper.findComponent(CreateUserForm)).toBeTruthy();
+	});
 
 	it('Should has imported a BreedForm Component', () => {
-		expect(wrapper.findComponent(BreedForm)).toBeTruthy()
-	})
+		expect(wrapper.findComponent(BreedForm)).toBeTruthy();
+	});
 
 	it('Should has a method to open ServiceForm', () => {
-		expect(wrapper.vm.launchServiceForm).toBeTruthy()
-	})
+		expect(wrapper.vm.launchServiceForm).toBeTruthy();
+	});
 
 	it('Should has a method to open CreateUserForm', () => {
-		expect(wrapper.vm.launchUserForm).toBeTruthy()
-	})
+		expect(wrapper.vm.launchUserForm).toBeTruthy();
+	});
 
 	it('Should has a method to open BreedForm', () => {
-		expect(wrapper.vm.launchBreedForm).toBeTruthy()
-	})
+		expect(wrapper.vm.launchBreedForm).toBeTruthy();
+	});
 
 	it('Should has a method to open Delete Confirmation', () => {
-		expect(wrapper.vm.launchDeleteConfirmation).toBeTruthy()
-	})
-})
+		expect(wrapper.vm.launchDeleteConfirmation).toBeTruthy();
+	});
+
+	it("Shouldn't show delete button if user is admin", () => {
+		const wrapper2 = shallowMount(TableEditDelete, {
+			propsData: {
+				id: '123',
+				text: 'message',
+				type: 'type',
+				userType: 'admin'
+			}, localVue });
+
+		expect(wrapper2.get('#table-edit-delete').get('#button-container').find('#delete').exists()).toBeFalsy();
+	});
+});


### PR DESCRIPTION
## Description
Check in the component whether or not the displayed user is an admin. If it's indeed an admin, don't show delete button.

Fixes #52 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [ ] table-edit-delete.spec.js

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
