### PR TITLE
Admin can set user's full name and branch office

### DIFF
--- a/src/components/CreateUserForm.vue
+++ b/src/components/CreateUserForm.vue
@@ -13,7 +13,7 @@ form#create-user-form
 					type='text'
 					minlength='4'
 					v-model='username'
-					required='true'
+					required
 				)
 			b-field#change-password(
 				label='Change Password'
@@ -24,7 +24,7 @@ form#create-user-form
 					type='password'
 					minlength='8'
 					v-model='password'
-					required='true'
+					required
 				)
 			b-field#confirm-password( label='Confirm Password' )
 				b-input(
@@ -32,8 +32,22 @@ form#create-user-form
 					minlength='8'
 					:validation-message='validationMessageConfirmPassword'
 					v-model='confirmPassword'
-					required='true'
+					required
 				)
+			b-field#fullname( label='Full Name' )
+				b-input(
+					type='text'
+					v-model='fullName'
+				)
+			b-field#branch-office( label='Branch Office' )
+				b-select(
+					v-model='branchOffice'
+				)
+					option(
+						v-for='(branch, index) in branchOffices'
+						:key='index'
+						:value='branch'
+					) {{ branch.name }}
 		footer.modal-card-foot
 			button.button(
 				type='button'
@@ -88,6 +102,8 @@ export default {
 			username: '',
 			password: '',
 			confirmPassword: '',
+			fullName: '',
+			branchOffice: '',
 			validationMessageConfirmPassword: '',
 			status: null,
 			type: 'medic'
@@ -149,7 +165,9 @@ export default {
 			axios.post(process.env.VUE_APP_TYRAWEB_CREATE_USER, {
 				username: this.username,
 				password: this.password,
-				type: this.type
+				type: this.type,
+				fullName: this.fullName,
+				branchOffice: this.branchOffice
 			}, {
 				headers: {
 					Authorization: 'Bearer ' + this.user.token
@@ -170,8 +188,11 @@ export default {
 					Authorization: 'Bearer ' + this.user.token
 				}
 			}).then(response => {
+				console.log(response.data)
 				this.username = response.data.username
 				this.type = response.data.type.name
+				this.fullName = response.data.fullName
+				this.branchOffice = response.data.branchOffice.name
 			}).catch(error => {
 				this.setOnError(error)
 			})
@@ -182,7 +203,9 @@ export default {
 				id: this.userId,
 				username: this.username,
 				password: this.password,
-				type: this.type
+				type: this.type,
+				fullName: this.fullName,
+				branchOffice: this.branchOffice
 			}, {
 				headers: {
 					Authorization: 'Bearer ' + this.user.token

--- a/tests/unit/create-user-form.spec.js
+++ b/tests/unit/create-user-form.spec.js
@@ -1,11 +1,11 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils'
-import store from '@/store'
-import Buefy from 'buefy'
-import CreateUserForm from '@/components/CreateUserForm.vue'
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import store from '@/store';
+import Buefy from 'buefy';
+import CreateUserForm from '@/components/CreateUserForm.vue';
 
 /* We import createLocalVue to load Buefy and store */
-const localVue = createLocalVue()
-localVue.use(Buefy)
+const localVue = createLocalVue();
+localVue.use(Buefy);
 
 /* Dummy User */
 store.state.user = {
@@ -13,142 +13,159 @@ store.state.user = {
 	username: '',
 	type: { name: '' },
 	token: ''
-}
+};
 
-const wrapper = shallowMount(CreateUserForm, { store, localVue })
+const wrapper = shallowMount(CreateUserForm, { store, localVue });
 
 describe('CreateUserForm Component', () => {
-	const data = CreateUserForm.data()
+	const data = CreateUserForm.data();
 	it('Set the correct default data', () => {
-		expect(typeof CreateUserForm.data).toBe('function')
-		expect(data.title).toMatch('')
-		expect(data.username).toMatch('')
-		expect(data.password).toMatch('')
-		expect(data.confirmPassword).toMatch('')
-		expect(data.validationMessageConfirmPassword).toMatch('')
-		expect(data.status).toBeNull()
-		expect(data.type).toMatch('medic')
-	})
+		expect(typeof CreateUserForm.data).toBe('function');
+		expect(data.title).toMatch('');
+		expect(data.username).toMatch('');
+		expect(data.password).toMatch('');
+		expect(data.confirmPassword).toMatch('');
+		expect(data.fullName).toMatch('');
+		expect(data.branchOffice).toMatch('');
+		expect(data.validationMessageConfirmPassword).toMatch('');
+		expect(data.status).toBeNull();
+		expect(data.type).toMatch('medic');
+	});
 
-	const main = wrapper.get('#create-user-form')
+	const main = wrapper.get('#create-user-form');
 	it('Should has a main container', () => {
-		expect(main.exists()).toBeTruthy()
-	})
+		expect(main.exists()).toBeTruthy();
+	});
 
-	const modal = main.get('div')
+	const modal = main.get('div');
 	it('Should has a modal', () => {
-		expect(modal.exists()).toBeTruthy()
-	})
+		expect(modal.exists()).toBeTruthy();
+	});
 
-	const modalHeader = modal.get('.modal-card-head')
+	const modalHeader = modal.get('.modal-card-head');
 	it('Should has a modal Header', () => {
-		expect(modalHeader.exists()).toBeTruthy()
+		expect(modalHeader.exists()).toBeTruthy();
 
-		const title = modalHeader.get('.modal-card-title')
-		expect(title.exists()).toBeTruthy()
-		expect(title.text()).toMatch(data.title)
+		const title = modalHeader.get('.modal-card-title');
+		expect(title.exists()).toBeTruthy();
+		expect(title.text()).toMatch(data.title);
 
-		const button = modalHeader.get('button')
-		expect(button.exists()).toBeTruthy()
-		expect(button.attributes().type).toMatch('button')
-	})
+		const button = modalHeader.get('button');
+		expect(button.exists()).toBeTruthy();
+		expect(button.attributes().type).toMatch('button');
+	});
 
-	const modalBody = modal.get('.modal-card-body')
+	const modalBody = modal.get('.modal-card-body');
 	it('Should has a modal Body', () => {
-		expect(modalBody.exists()).toBeTruthy()
+		expect(modalBody.exists()).toBeTruthy();
 
-		const usernameLabel = modalBody.get('#username')
-		expect(usernameLabel.exists()).toBeTruthy()
-		expect(usernameLabel.attributes().label).toMatch('Username')
+		const usernameLabel = modalBody.get('#username');
+		expect(usernameLabel.exists()).toBeTruthy();
+		expect(usernameLabel.attributes().label).toMatch('Username');
 
-		const usernameInput = usernameLabel.get('b-input-stub')
-		expect(usernameInput.exists()).toBeTruthy()
-		expect(usernameInput.attributes().type).toMatch('text')
-		expect(usernameInput.attributes().minlength).toMatch('4')
-		expect(usernameInput.attributes().required).toBeTruthy()
+		const usernameInput = usernameLabel.get('b-input-stub');
+		expect(usernameInput.exists()).toBeTruthy();
+		expect(usernameInput.attributes().type).toMatch('text');
+		expect(usernameInput.attributes().minlength).toMatch('4');
+		expect(usernameInput.attributes().required).toMatch('');
 
-		const passwordLabel = modalBody.get('#password')
-		expect(passwordLabel.exists()).toBeTruthy()
-		expect(passwordLabel.attributes().label).toMatch('Password')
+		const passwordLabel = modalBody.get('#password');
+		expect(passwordLabel.exists()).toBeTruthy();
+		expect(passwordLabel.attributes().label).toMatch('Password');
 
-		const passwordInput = passwordLabel.get('b-input-stub')
-		expect(passwordInput.exists()).toBeTruthy()
-		expect(passwordInput.attributes().type).toMatch('password')
-		expect(passwordInput.attributes().minlength).toMatch('8')
-		expect(passwordInput.attributes().required).toBeTruthy()
+		const passwordInput = passwordLabel.get('b-input-stub');
+		expect(passwordInput.exists()).toBeTruthy();
+		expect(passwordInput.attributes().type).toMatch('password');
+		expect(passwordInput.attributes().minlength).toMatch('8');
+		expect(passwordInput.attributes().required).toMatch('');
 
-		const confirmPassLabel = modalBody.get('#confirm-password')
-		expect(confirmPassLabel.exists()).toBeTruthy()
-		expect(confirmPassLabel.attributes().label).toMatch('Confirm Password')
+		const confirmPassLabel = modalBody.get('#confirm-password');
+		expect(confirmPassLabel.exists()).toBeTruthy();
+		expect(confirmPassLabel.attributes().label).toMatch('Confirm Password');
 
-		const confirmPassInput = confirmPassLabel.get('b-input-stub')
-		expect(confirmPassInput.exists()).toBeTruthy()
-		expect(confirmPassInput.attributes().type).toMatch('password')
-		expect(confirmPassInput.attributes().minlength).toMatch('8')
-		expect(confirmPassInput.attributes().required).toBeTruthy()
-	})
+		const confirmPassInput = confirmPassLabel.get('b-input-stub');
+		expect(confirmPassInput.exists()).toBeTruthy();
+		expect(confirmPassInput.attributes().type).toMatch('password');
+		expect(confirmPassInput.attributes().minlength).toMatch('8');
+		expect(confirmPassInput.attributes().required).toMatch('');
 
-	const modalFooter = modal.get('.modal-card-foot')
+		const fullNameLabel = modalBody.get('#fullname');
+		expect(fullNameLabel.exists()).toBeTruthy();
+		expect(fullNameLabel.attributes().label).toMatch('Full Name');
+
+		const fullNameInput = fullNameLabel.get('b-input-stub');
+		expect(fullNameInput.exists()).toBeTruthy();
+		expect(fullNameInput.attributes().type).toMatch('text');
+
+		const branchOfficeLabel = modalBody.get('#branch-office');
+		expect(branchOfficeLabel.exists()).toBeTruthy();
+		expect(branchOfficeLabel.attributes().label).toMatch('Branch Office');
+
+		const branchOfficeSelect = branchOfficeLabel.get('b-select-stub');
+		expect(branchOfficeSelect.exists()).toBeTruthy();
+	});
+
+	const modalFooter = modal.get('.modal-card-foot');
 	it('Should has a modal Footer', async () => {
-		expect(modalFooter.exists()).toBeTruthy()
+		expect(modalFooter.exists()).toBeTruthy();
 
-		const cancelButton = modalFooter.get('button')
-		expect(cancelButton.exists()).toBeTruthy()
-		expect(cancelButton.attributes().type).toMatch('button')
-		expect(cancelButton.text()).toMatch('Cancel')
+		const cancelButton = modalFooter.get('button');
+		expect(cancelButton.exists()).toBeTruthy();
+		expect(cancelButton.attributes().type).toMatch('button');
+		expect(cancelButton.text()).toMatch('Cancel');
 
-		const acceptButton = modalFooter.get('b-button-stub')
-		expect(acceptButton.exists()).toBeTruthy()
-		expect(acceptButton.classes('button')).toBeTruthy()
-		expect(acceptButton.classes('is-success')).toBeTruthy()
-		expect(acceptButton.text()).toMatch('Accept')
+		const acceptButton = modalFooter.get('b-button-stub');
+		expect(acceptButton.exists()).toBeTruthy();
+		expect(acceptButton.classes('button')).toBeTruthy();
+		expect(acceptButton.classes('is-success')).toBeTruthy();
+		expect(acceptButton.text()).toMatch('Accept');
 
-		await wrapper.setData({ status: 200 })
-		const successIcon = modalFooter.get('#success-icon')
-		expect(successIcon.exists()).toBeTruthy()
-		expect(successIcon.attributes().title).toMatch('Success')
-		expect(successIcon.attributes().type).toMatch('is-success')
-		expect(successIcon.attributes().pack).toMatch('fas')
-		expect(successIcon.attributes().size).toMatch('is-large')
-		expect(successIcon.attributes().icon).toMatch('check')
+		await wrapper.setData({ status: 200 });
+		const successIcon = modalFooter.get('#success-icon');
+		expect(successIcon.exists()).toBeTruthy();
+		expect(successIcon.attributes().title).toMatch('Success');
+		expect(successIcon.attributes().type).toMatch('is-success');
+		expect(successIcon.attributes().pack).toMatch('fas');
+		expect(successIcon.attributes().size).toMatch('is-large');
+		expect(successIcon.attributes().icon).toMatch('check');
 
-		await wrapper.setData({ status: 401 })
-		const errorIcon = modalFooter.get('#error-icon')
-		expect(errorIcon.exists()).toBeTruthy()
-		expect(errorIcon.attributes().title).toMatch('Error')
-		expect(errorIcon.attributes().type).toMatch('is-danger')
-		expect(errorIcon.attributes().pack).toMatch('fas')
-		expect(errorIcon.attributes().size).toMatch('is-large')
-		expect(errorIcon.attributes().icon).toMatch('exclamation')
-	})
+		await wrapper.setData({ status: 401 });
+		const errorIcon = modalFooter.get('#error-icon');
+		expect(errorIcon.exists()).toBeTruthy();
+		expect(errorIcon.attributes().title).toMatch('Error');
+		expect(errorIcon.attributes().type).toMatch('is-danger');
+		expect(errorIcon.attributes().pack).toMatch('fas');
+		expect(errorIcon.attributes().size).toMatch('is-large');
+		expect(errorIcon.attributes().icon).toMatch('exclamation');
+	});
 
 	it('Should change title and change password label if ID is sent', async () => {
-		const title = modalHeader.get('.modal-card-title')
-		expect(title.text()).toMatch('Create User')
+		const title = modalHeader.get('.modal-card-title');
+		expect(title.text()).toMatch('Create User');
 
 		/* Send ID on mount */
 		const wrapper2 = shallowMount(CreateUserForm, {
 			propsData: {
 				userId: 'test'
 			}, store, localVue })
-		const main2 = wrapper2.get('#create-user-form')
-		const modal2 = main2.get('div')
-		const modalHeader2 = modal2.get('.modal-card-head')
-		const modalBody2 = modal2.get('.modal-card-body')
+		const main2 = wrapper2.get('#create-user-form');
+		const modal2 = main2.get('div');
+		const modalHeader2 = modal2.get('.modal-card-head');
+		const modalBody2 = modal2.get('.modal-card-body');
 
-		expect(modalHeader2.get('.modal-card-title').text()).toMatch('Edit User')
-		expect(modalBody2.get('#change-password').exists()).toBeTruthy()
-	})
+		expect(modalHeader2.get('.modal-card-title').text()).toMatch('Edit User');
+		expect(modalBody2.get('#change-password').exists()).toBeTruthy();
+	});
 
 	it('Should has an init method', () => {
-		expect(wrapper.vm.init).toBeTruthy()
-	})
+		expect(wrapper.vm.init).toBeTruthy();
+	});
 
 	it('Should has a close method', () => {
-		expect(wrapper.vm.close).toBeTruthy()
-	})
+		expect(wrapper.vm.close).toBeTruthy();
+	});
 
 	it('Should has a send method', () => {
-		expect(wrapper.vm.send).toBeTruthy()
-	})
-})
+		expect(wrapper.vm.send).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Description
Updated create user form to set the full name of the user and set the branch office where the user is working

Fixes #63 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x]  create-user-form.spec.js

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings